### PR TITLE
Retrait des doubles references aux tables enumerees dans le files.json

### DIFF
--- a/config/cnig_PPR_v1.0_geopackage/files.json
+++ b/config/cnig_PPR_v1.0_geopackage/files.json
@@ -63,18 +63,6 @@
           "tableModel": "./types/typeppr_codegaspar_referenceinternet.json"
         },
         {
-          "name": "typeprocedure",
-          "tableModel": "./types/typeprocedure.json"
-        },
-        {
-          "name": "typeetatprocedure",
-          "tableModel": "./types/typeetatprocedure.json"
-        },
-        {
-          "name": "typereference",
-          "tableModel": "./types/typereference.json"
-        },
-        {
           "name": "typeppr_codegaspar_zonealeareference_codealea_s",
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_zonealeareference_[1-3][0-9]{1,2}_s",
           "tableModel": "./types/typeppr_codegaspar_zonealeareference_codealea_s.json"
@@ -150,34 +138,6 @@
           "tableModel": "./types/typeppr_codegaspar_ouvrageprotecteur_codealea_s.json"
         },
         {
-          "name": "typealea",
-          "tableModel": "./types/typealea.json"
-        },
-        {
-          "name": "typeniveaualea",
-          "tableModel": "./types/typeniveaualea.json"
-        },
-        {
-          "name": "typesuralea",
-          "tableModel": "./types/typesuralea.json"
-        },
-        {
-          "name": "typeouvrageprotecteur",
-          "tableModel": "./types/typeouvrageprotecteur.json"
-        },
-        {
-          "name": "typerefexterneouvrage",
-          "tableModel": "./types/typerefexterneouvrage.json"
-        },
-        {
-          "name": "typeintensitetechno",
-          "tableModel": "./types/typeintensitetechno.json"
-        },
-        {
-          "name": "typeclasseprobatechno",
-          "tableModel": "./types/typeclasseprobatechno.json"
-        },
-        {
           "name": "typeppr_codegaspar_originerisque_l",
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_originerisque_l",
           "tableModel": "./types/typeppr_codegaspar_originerisque_l.json"
@@ -211,21 +171,6 @@
           "name": "typeppr_codegaspar_typevulnerabilite",
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_typevulnerabilite",
           "tableModel": "./types/typeppr_codegaspar_typevulnerabilite.json"
-        },
-        {
-          "name": "typeenjeupprn",
-          "path": "typeenjeupprn",
-          "tableModel": "./types/typeenjeupprn.json"
-        },
-        {
-          "name": "typeenjeupprt",
-          "path": "typeenjeupprt",
-          "tableModel": "./types/typeenjeupprt.json"
-        },
-        {
-          "name": "typeenjeucovadis",
-          "path": "typeenjeucovadis",
-          "tableModel": "./types/typeenjeucovadis.json"
         },
         {
           "name": "typeppr_codegaspar_zonereglementaireurba_l",
@@ -263,14 +208,6 @@
           "name": "typeppr_codegaspar_zoneregmultialea",
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_zoneregmultialea",
           "tableModel": "./types/typeppr_codegaspar_zoneregmultialea.json"
-        },
-        {
-          "name": "typereglementurba",
-          "tableModel": "./types/typereglementurba.json"
-        },
-        {
-          "name": "typereglementfoncier",
-          "tableModel": "./types/typereglementfoncier.json"
         }
       ]
     }

--- a/config/cnig_PPR_v1.0_shapefile/files.json
+++ b/config/cnig_PPR_v1.0_shapefile/files.json
@@ -37,21 +37,6 @@
           "tableModel": "./types/typeppr_codegaspar_referenceinternet.json"
         },
         {
-          "name": "typeprocedure",
-          "type": "table",
-          "tableModel": "./types/typeprocedure.json"
-        },
-        {
-          "name": "typeetatprocedure",
-          "type": "table",
-          "tableModel": "./types/typeetatprocedure.json"
-        },
-        {
-          "name": "typereference",
-          "type": "table",
-          "tableModel": "./types/typereference.json"
-        },
-        {
           "name": "typeppr_codegaspar_zonealeareference_codealea_s",
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_zonealeareference_[1-3][0-9]{1,2}_s",
           "type": "table",
@@ -142,41 +127,6 @@
           "tableModel": "./types/typeppr_codegaspar_ouvrageprotecteur_codealea_s.json"
         },
         {
-          "name": "typealea",
-          "type": "table",
-          "tableModel": "./types/typealea.json"
-        },
-        {
-          "name": "typeniveaualea",
-          "type": "table",
-          "tableModel": "./types/typeniveaualea.json"
-        },
-        {
-          "name": "typesuralea",
-          "type": "table",
-          "tableModel": "./types/typesuralea.json"
-        },
-        {
-          "name": "typeouvrageprotecteur",
-          "type": "table",
-          "tableModel": "./types/typeouvrageprotecteur.json"
-        },
-        {
-          "name": "typerefexterneouvrage",
-          "type": "table",
-          "tableModel": "./types/typerefexterneouvrage.json"
-        },
-        {
-          "name": "typeintensitetechno",
-          "type": "table",
-          "tableModel": "./types/typeintensitetechno.json"
-        },
-        {
-          "name": "typeclasseprobatechno",
-          "type": "table",
-          "tableModel": "./types/typeclasseprobatechno.json"
-        },
-        {
           "name": "typeppr_codegaspar_originerisque_l",
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_originerisque_l",
           "type": "table",
@@ -217,24 +167,6 @@
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_typevulnerabilite",
           "type": "table",
           "tableModel": "./types/typeppr_codegaspar_typevulnerabilite.json"
-        },
-        {
-          "name": "typeenjeupprn",
-          "path": "typeenjeupprn",
-          "type": "table",
-          "tableModel": "./types/typeenjeupprn.json"
-        },
-        {
-          "name": "typeenjeupprt",
-          "path": "typeenjeupprt",
-          "type": "table",
-          "tableModel": "./types/typeenjeupprt.json"
-        },
-        {
-          "name": "typeenjeucovadis",
-          "path": "typeenjeucovadis",
-          "type": "table",
-          "tableModel": "./types/typeenjeucovadis.json"
         },
         {
           "name": "typeppr_codegaspar_zonereglementaireurba_l",
@@ -279,16 +211,6 @@
           "path": "ppr[a-zA-Z]_[0-9]{2,3}(PREF|DDT|DDTM|DREAL|DRIEAT)[0-9]{4}[0-9]{4}_zoneregmultialea",
           "type": "table",
           "tableModel": "./types/typeppr_codegaspar_zoneregmultialea.json"
-        },
-        {
-          "name": "typereglementurba",
-          "type": "table",
-          "tableModel": "./types/typereglementurba.json"
-        },
-        {
-          "name": "typereglementfoncier",
-          "type": "table",
-          "tableModel": "./types/typereglementfoncier.json"
         }
   ],
   "codes": [


### PR DESCRIPTION
Cette PR est pour pallier à l'erreur constatée [ici](https://validtri.mut-dev.ign.fr/api/validations/4879wgxp4hqnr8n0mhvi3eb0 ) lors du chargement de la config car les tables énumérées sont déclarées deux fois dans le files.json (sous forme de tables énumérées ('codes") et sous forme de tables ("types") qui semble provoquer une tentative de création en double de la même table. 
Dans cette PR on ne conserve que les déclaration dans "codes" et les tables csv associées. Les fichiers json correspondants sont maintenus mais ne sont plus référencés. Ils pourront être supprimés par la suite si besoin.