### PR TITLE
Prise en compte de la présence des tables d'énumération

### DIFF
--- a/config/cnig_PPR_v1.0_geopackage/files.json
+++ b/config/cnig_PPR_v1.0_geopackage/files.json
@@ -212,77 +212,77 @@
         {
           "name": "typealea",
           "path": "typealea",
-          "data": "./types/typealea.json"
+          "tableModel": "./types/typealea.json"
         },
         {
           "name": "typeetatprocedure",
           "path": "typeetatprocedure",
-          "data": "./types/typeetatprocedure.json"
+          "tableModel": "./types/typeetatprocedure.json"
         },
         {
           "name": "typereference",
           "path": "typereference",
-          "data": "./types/typereference.json"
+          "tableModel": "./types/typereference.json"
         },
         {
           "name": "typeclasseprobatechno",
           "path": "typeclasseprobatechno",
-          "data": "./types/typeclasseprobatechno.json"
+          "tableModel": "./types/typeclasseprobatechno.json"
         },
         {
           "name": "typeintensitetechno",
           "path": "typeintensitetechno",
-          "data": "./types/typeintensitetechno.json"
+          "tableModel": "./types/typeintensitetechno.json"
         },
         {
           "name": "typerefexterneouvrage",
           "path": "typerefexterneouvrage",
-          "data": "./types/typerefexterneouvrage.json"
+          "tableModel": "./types/typerefexterneouvrage.json"
         },
         {
           "name": "typeenjeucovadis",
           "path": "typeenjeucovadis",
-          "data": "./types/typeenjeucovadis.json"
+          "tableModel": "./types/typeenjeucovadis.json"
         },
         {
           "name": "typeniveaualea",
           "path": "typeniveaualea",
-          "data": "./types/typeniveaualea.json"
+          "tableModel": "./types/typeniveaualea.json"
         },
         {
           "name": "typereglementfoncier",
           "path": "typereglementfoncier",
-          "data": "./types/typereglementfoncier.json"
+          "tableModel": "./types/typereglementfoncier.json"
         },
         {
           "name": "typeenjeupprn",
           "path": "typeenjeupprn",
-          "data": "./types/typeenjeupprn.json"
+          "tableModel": "./types/typeenjeupprn.json"
         },
         {
           "name": "typeenjeupprt",
           "path": "typeenjeupprt",
-          "data": "./types/typeenjeupprt.json"
+          "tableModel": "./types/typeenjeupprt.json"
         },
         {
           "name": "typeouvrageprotecteur",
           "path": "typeouvrageprotecteur",
-          "data": "./types/typeouvrageprotecteur.json"
+          "tableModel": "./types/typeouvrageprotecteur.json"
         },
         {
           "name": "typereglementurba",
           "path": "typereglementurba",
-          "data": "./types/typereglementurba.json"
+          "tableModel": "./types/typereglementurba.json"
         },
         {
           "name": "typeprocedure",
           "path": "typeprocedure",
-          "data": "./types/typeprocedure.json"
+          "tableModel": "./types/typeprocedure.json"
         },
         {
           "name": "typesuralea",
           "path": "typesuralea",
-          "data": "./types/typesuralea.json"
+          "tableModel": "./types/typesuralea.json"
         }
       ]
     }

--- a/config/cnig_PPR_v1.0_geopackage/files.json
+++ b/config/cnig_PPR_v1.0_geopackage/files.json
@@ -208,86 +208,160 @@
           "name": "prefixeppr_zoneregmultialea",
           "path": "((pprn|pprt|pprm)_(?:[0-9]{2,3}|2a|2b)(pref|ddt|ddtm|dreal|deal|drieat)[0-9]{4}[0-9]{4}|(pprn_i|pprn_l|pprn_mvt|pprn_multi|pprn_s|pprn_av|pprn_ev|pprn_cy|pprn_rga|pprn_if|pprt|pprm|ppr_hybride)_[0-9]{4}_[0-9]{4})_zoneregmultialea",
           "tableModel": "./types/prefixeppr_zoneregmultialea.json"
+        },
+        {
+          "name": "typealea",
+          "path": "typealea",
+          "data": "./types/typealea.json"
+        },
+        {
+          "name": "typeetatprocedure",
+          "path": "typeetatprocedure",
+          "data": "./types/typeetatprocedure.json"
+        },
+        {
+          "name": "typereference",
+          "path": "typereference",
+          "data": "./types/typereference.json"
+        },
+        {
+          "name": "typeclasseprobatechno",
+          "path": "typeclasseprobatechno",
+          "data": "./types/typeclasseprobatechno.json"
+        },
+        {
+          "name": "typeintensitetechno",
+          "path": "typeintensitetechno",
+          "data": "./types/typeintensitetechno.json"
+        },
+        {
+          "name": "typerefexterneouvrage",
+          "path": "typerefexterneouvrage",
+          "data": "./types/typerefexterneouvrage.json"
+        },
+        {
+          "name": "typeenjeucovadis",
+          "path": "typeenjeucovadis",
+          "data": "./types/typeenjeucovadis.json"
+        },
+        {
+          "name": "typeniveaualea",
+          "path": "typeniveaualea",
+          "data": "./types/typeniveaualea.json"
+        },
+        {
+          "name": "typereglementfoncier",
+          "path": "typereglementfoncier",
+          "data": "./types/typereglementfoncier.json"
+        },
+        {
+          "name": "typeenjeupprn",
+          "path": "typeenjeupprn",
+          "data": "./types/typeenjeupprn.json"
+        },
+        {
+          "name": "typeenjeupprt",
+          "path": "typeenjeupprt",
+          "data": "./types/typeenjeupprt.json"
+        },
+        {
+          "name": "typeouvrageprotecteur",
+          "path": "typeouvrageprotecteur",
+          "data": "./types/typeouvrageprotecteur.json"
+        },
+        {
+          "name": "typereglementurba",
+          "path": "typereglementurba",
+          "data": "./types/typereglementurba.json"
+        },
+        {
+          "name": "typeprocedure",
+          "path": "typeprocedure",
+          "data": "./types/typeprocedure.json"
+        },
+        {
+          "name": "typesuralea",
+          "path": "typesuralea",
+          "data": "./types/typesuralea.json"
         }
       ]
     }
   ],
   "codes": [
-
     {
-        "name": "typealea",
-        "title": "typealea",
-        "data": "./codes/typealea.csv"
+      "name": "typealea",
+      "title": "typealea",
+      "data": "./codes/typealea.csv"
     },
     {
-        "name": "typeetatprocedure",
-        "title": "typeetatprocedure",
-        "data": "./codes/typeetatprocedure.csv"
+      "name": "typeetatprocedure",
+      "title": "typeetatprocedure",
+      "data": "./codes/typeetatprocedure.csv"
     },
     {
-        "name": "typereference",
-        "title": "typereference",
-        "data": "./codes/typereference.csv"
+      "name": "typereference",
+      "title": "typereference",
+      "data": "./codes/typereference.csv"
     },
     {
-        "name": "typeclasseprobatechno",
-        "title": "typeclasseprobatechno",
-        "data": "./codes/typeclasseprobatechno.csv"
+      "name": "typeclasseprobatechno",
+      "title": "typeclasseprobatechno",
+      "data": "./codes/typeclasseprobatechno.csv"
     },
     {
-        "name": "typeintensitetechno",
-        "title": "typeintensitetechno",
-        "data": "./codes/typeintensitetechno.csv"
+      "name": "typeintensitetechno",
+      "title": "typeintensitetechno",
+      "data": "./codes/typeintensitetechno.csv"
     },
     {
-        "name": "typerefexterneouvrage",
-        "title": "typerefexterneouvrage",
-        "data": "./codes/typerefexterneouvrage.csv"
+      "name": "typerefexterneouvrage",
+      "title": "typerefexterneouvrage",
+      "data": "./codes/typerefexterneouvrage.csv"
     },
     {
-        "name": "typeenjeucovadis",
-        "title": "typeenjeucovadis",
-        "data": "./codes/typeenjeucovadis.csv"
+      "name": "typeenjeucovadis",
+      "title": "typeenjeucovadis",
+      "data": "./codes/typeenjeucovadis.csv"
     },
     {
-        "name": "typeniveaualea",
-        "title": "typeniveaualea",
-        "data": "./codes/typeniveaualea.csv"
+      "name": "typeniveaualea",
+      "title": "typeniveaualea",
+      "data": "./codes/typeniveaualea.csv"
     },
     {
-        "name": "typereglementfoncier",
-        "title": "typereglementfoncier",
-        "data": "./codes/typereglementfoncier.csv"
+      "name": "typereglementfoncier",
+      "title": "typereglementfoncier",
+      "data": "./codes/typereglementfoncier.csv"
     },
     {
-        "name": "typeenjeupprn",
-        "title": "typeenjeupprn",
-        "data": "./codes/typeenjeupprn.csv"
+      "name": "typeenjeupprn",
+      "title": "typeenjeupprn",
+      "data": "./codes/typeenjeupprn.csv"
     },
     {
-        "name": "typeenjeupprt",
-        "title": "typeenjeupprt",
-        "data": "./codes/typeenjeupprt.csv"
+      "name": "typeenjeupprt",
+      "title": "typeenjeupprt",
+      "data": "./codes/typeenjeupprt.csv"
     },
     {
-        "name": "typeouvrageprotecteur",
-        "title": "typeouvrageprotecteur",
-        "data": "./codes/typeouvrageprotecteur.csv"
+      "name": "typeouvrageprotecteur",
+      "title": "typeouvrageprotecteur",
+      "data": "./codes/typeouvrageprotecteur.csv"
     },
     {
-        "name": "typereglementurba",
-        "title": "typereglementurba",
-        "data": "./codes/typereglementurba.csv"
+      "name": "typereglementurba",
+      "title": "typereglementurba",
+      "data": "./codes/typereglementurba.csv"
     },
     {
-        "name": "typeprocedure",
-        "title": "typeprocedure",
-        "data": "./codes/typeprocedure.csv"
+      "name": "typeprocedure",
+      "title": "typeprocedure",
+      "data": "./codes/typeprocedure.csv"
     },
     {
-        "name": "typesuralea",
-        "title": "typesuralea",
-        "data": "./codes/typesuralea.csv"
+      "name": "typesuralea",
+      "title": "typesuralea",
+      "data": "./codes/typesuralea.csv"
     }
   ]
 }

--- a/config/cnig_PPR_v1.0_geopackage/types/prefixeppr_originerisque_p.json
+++ b/config/cnig_PPR_v1.0_geopackage/types/prefixeppr_originerisque_p.json
@@ -18,7 +18,7 @@
       "constraints": {
         "required": true,
         "maxLength": 22,
-          "reference": "prefixeppr_procedure.codeprocedure"
+        "reference": "prefixeppr_procedure.codeprocedure"
       }
     },
     {

--- a/config/cnig_PPR_v1.0_geopackage/types/typereference.json
+++ b/config/cnig_PPR_v1.0_geopackage/types/typereference.json
@@ -8,7 +8,7 @@
       "type": "String",
       "constraints": {
         "required": true,
-        "maxLength": 10
+        "maxLength": 2
       }
     },
     {

--- a/config/cnig_PPR_v1.0_shapefile/files.json
+++ b/config/cnig_PPR_v1.0_shapefile/files.json
@@ -211,10 +211,100 @@
           "path": "((pprn|pprt|pprm)_(?:[0-9]{2,3}|2a|2b)(pref|ddt|ddtm|dreal|deal|drieat)[0-9]{4}[0-9]{4}|(pprn_i|pprn_l|pprn_mvt|pprn_multi|pprn_s|pprn_av|pprn_ev|pprn_cy|pprn_rga|pprn_if|pprt|pprm|ppr_hybride)_[0-9]{4}_[0-9]{4})_zoneregmultialea",
           "type": "table",
           "tableModel": "./types/prefixeppr_zoneregmultialea.json"
+        },
+                {
+          "name": "typealea",
+          "path": "typealea",
+          "type": "table",
+          "data": "./types/typealea.json"
+        },
+        {
+          "name": "typeetatprocedure",
+          "path": "typeetatprocedure",
+          "type": "table",
+          "data": "./types/typeetatprocedure.json"
+        },
+        {
+          "name": "typereference",
+          "path": "typereference",
+          "type": "table",
+          "data": "./types/typereference.json"
+        },
+        {
+          "name": "typeclasseprobatechno",
+          "path": "typeclasseprobatechno",
+          "type": "table",
+          "data": "./types/typeclasseprobatechno.json"
+        },
+        {
+          "name": "typeintensitetechno",
+          "path": "typeintensitetechno",
+          "type": "table",
+          "data": "./types/typeintensitetechno.json"
+        },
+        {
+          "name": "typerefexterneouvrage",
+          "path": "typerefexterneouvrage",
+          "type": "table",
+          "data": "./types/typerefexterneouvrage.json"
+        },
+        {
+          "name": "typeenjeucovadis",
+          "path": "typeenjeucovadis",
+          "type": "table",
+          "data": "./types/typeenjeucovadis.json"
+        },
+        {
+          "name": "typeniveaualea",
+          "path": "typeniveaualea",
+          "type": "table",
+          "data": "./types/typeniveaualea.json"
+        },
+        {
+          "name": "typereglementfoncier",
+          "path": "typereglementfoncier",
+          "type": "table",
+          "data": "./types/typereglementfoncier.json"
+        },
+        {
+          "name": "typeenjeupprn",
+          "path": "typeenjeupprn",
+          "type": "table",
+          "data": "./types/typeenjeupprn.json"
+        },
+        {
+          "name": "typeenjeupprt",
+          "path": "typeenjeupprt",
+          "type": "table",
+          "data": "./types/typeenjeupprt.json"
+        },
+        {
+          "name": "typeouvrageprotecteur",
+          "path": "typeouvrageprotecteur",
+          "type": "table",
+          "data": "./types/typeouvrageprotecteur.json"
+        },
+        {
+          "name": "typereglementurba",
+          "path": "typereglementurba",
+          "type": "table",
+          "data": "./types/typereglementurba.json"
+        },
+        {
+          "name": "typeprocedure",
+          "path": "typeprocedure",
+          "type": "table",
+          "data": "./types/typeprocedure.json"
+        },
+        {
+          "name": "typesuralea",
+          "path": "typesuralea",
+          "type": "table",
+          "data": "./types/typesuralea.json"
         }
+
   ],
   "codes": [
-
     {
         "name": "typealea",
         "title": "typealea",

--- a/config/cnig_PPR_v1.0_shapefile/files.json
+++ b/config/cnig_PPR_v1.0_shapefile/files.json
@@ -216,91 +216,91 @@
           "name": "typealea",
           "path": "typealea",
           "type": "table",
-          "data": "./types/typealea.json"
+          "tableModel": "./types/typealea.json"
         },
         {
           "name": "typeetatprocedure",
           "path": "typeetatprocedure",
           "type": "table",
-          "data": "./types/typeetatprocedure.json"
+          "tableModel": "./types/typeetatprocedure.json"
         },
         {
           "name": "typereference",
           "path": "typereference",
           "type": "table",
-          "data": "./types/typereference.json"
+          "tableModel": "./types/typereference.json"
         },
         {
           "name": "typeclasseprobatechno",
           "path": "typeclasseprobatechno",
           "type": "table",
-          "data": "./types/typeclasseprobatechno.json"
+          "tableModel": "./types/typeclasseprobatechno.json"
         },
         {
           "name": "typeintensitetechno",
           "path": "typeintensitetechno",
           "type": "table",
-          "data": "./types/typeintensitetechno.json"
+          "tableModel": "./types/typeintensitetechno.json"
         },
         {
           "name": "typerefexterneouvrage",
           "path": "typerefexterneouvrage",
           "type": "table",
-          "data": "./types/typerefexterneouvrage.json"
+          "tableModel": "./types/typerefexterneouvrage.json"
         },
         {
           "name": "typeenjeucovadis",
           "path": "typeenjeucovadis",
           "type": "table",
-          "data": "./types/typeenjeucovadis.json"
+          "tableModel": "./types/typeenjeucovadis.json"
         },
         {
           "name": "typeniveaualea",
           "path": "typeniveaualea",
           "type": "table",
-          "data": "./types/typeniveaualea.json"
+          "tableModel": "./types/typeniveaualea.json"
         },
         {
           "name": "typereglementfoncier",
           "path": "typereglementfoncier",
           "type": "table",
-          "data": "./types/typereglementfoncier.json"
+          "tableModel": "./types/typereglementfoncier.json"
         },
         {
           "name": "typeenjeupprn",
           "path": "typeenjeupprn",
           "type": "table",
-          "data": "./types/typeenjeupprn.json"
+          "tableModel": "./types/typeenjeupprn.json"
         },
         {
           "name": "typeenjeupprt",
           "path": "typeenjeupprt",
           "type": "table",
-          "data": "./types/typeenjeupprt.json"
+          "tableModel": "./types/typeenjeupprt.json"
         },
         {
           "name": "typeouvrageprotecteur",
           "path": "typeouvrageprotecteur",
           "type": "table",
-          "data": "./types/typeouvrageprotecteur.json"
+          "tableModel": "./types/typeouvrageprotecteur.json"
         },
         {
           "name": "typereglementurba",
           "path": "typereglementurba",
           "type": "table",
-          "data": "./types/typereglementurba.json"
+          "tableModel": "./types/typereglementurba.json"
         },
         {
           "name": "typeprocedure",
           "path": "typeprocedure",
           "type": "table",
-          "data": "./types/typeprocedure.json"
+          "tableModel": "./types/typeprocedure.json"
         },
         {
           "name": "typesuralea",
           "path": "typesuralea",
           "type": "table",
-          "data": "./types/typesuralea.json"
+          "tableModel": "./types/typesuralea.json"
         }
 
   ],

--- a/config/cnig_PPR_v1.0_shapefile/types/typereference.json
+++ b/config/cnig_PPR_v1.0_shapefile/types/typereference.json
@@ -8,7 +8,7 @@
       "type": "String",
       "constraints": {
         "required": true,
-        "maxLength": 10
+        "maxLength": 2
       }
     },
     {


### PR DESCRIPTION
Rajout des tables d'énumérations dans les file.json pour geopackage et shapefine  afin de ne pas lever de warning lorsqu'elles sont présentes.
Conséquence, si elles sont présentes leur structure sera testée à la validation.